### PR TITLE
Fix string null validation logic

### DIFF
--- a/src/DevSource.Stack.Notifications/Validations/ForStrings.cs
+++ b/src/DevSource.Stack.Notifications/Validations/ForStrings.cs
@@ -137,7 +137,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsNull(string key, string value)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             AddNotification(new Notification(Error.IsNull(key)));
         
         return this;
@@ -153,7 +153,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsNull(string key, string value, string message)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             AddNotification(new Notification(key, message));
         
         return this;
@@ -168,7 +168,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsNullOrEmpty(string key, string value)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             AddNotification(new Notification(key, Error.IsNullOrEmpty(key)));
         
         return this;
@@ -184,7 +184,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsNullOrEmpty(string key, string value, string message)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             AddNotification(new Notification(key, message));
         
         return this;
@@ -199,7 +199,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsNullOrWhiteSpace(string key, string value)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (!string.IsNullOrWhiteSpace(value))
             AddNotification(new Notification(key, Error.IsNullOrWhiteSpace(key)));
         
         return this;
@@ -215,7 +215,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsNullOrWhiteSpace(string key, string value, string message)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (!string.IsNullOrWhiteSpace(value))
             AddNotification(new Notification(key, message));
         
         return this;
@@ -264,7 +264,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsLengthLowerThan(string key, string value, int lowerThan)
     {
-        if (value.Length < lowerThan)
+        if (value.Length > lowerThan)
             AddNotification(new Notification(Error.IsLowerThan(key, lowerThan)));
         
         return this;
@@ -281,7 +281,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsLengthLowerThan(string key, string value, int lowerThan, string message)
     {
-        if (value.Length < lowerThan)
+        if (value.Length > lowerThan)
             AddNotification(new Notification(key, message));
         
         return this;

--- a/src/DevSource.Stack.Notifications/Validations/ForStringsException.cs
+++ b/src/DevSource.Stack.Notifications/Validations/ForStringsException.cs
@@ -137,7 +137,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsNull(string key, string value)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             PublishException(new DomainException(Error.IsNull(key)));
         
         return this;
@@ -153,7 +153,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsNull(string key, string value, string message)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             PublishException(new DomainException(key, message));
         
         return this;
@@ -168,7 +168,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsNullOrEmpty(string key, string value)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             PublishException(new DomainException(key, Error.IsNullOrEmpty(key)));
         
         return this;
@@ -184,7 +184,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsNullOrEmpty(string key, string value, string message)
     {
-        if (string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value))
             PublishException(new DomainException(key, message));
         
         return this;
@@ -199,7 +199,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsNullOrWhiteSpace(string key, string value)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (!string.IsNullOrWhiteSpace(value))
             PublishException(new DomainException(key, Error.IsNullOrWhiteSpace(key)));
         
         return this;
@@ -215,7 +215,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsNullOrWhiteSpace(string key, string value, string message)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (!string.IsNullOrWhiteSpace(value))
             PublishException(new DomainException(key, message));
         
         return this;
@@ -264,7 +264,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsLengthLowerThan(string key, string value, int lowerThan)
     {
-        if (value.Length < lowerThan)
+        if (value.Length > lowerThan)
             PublishException(new DomainException(Error.IsLowerThan(key, lowerThan)));
         
         return this;
@@ -281,7 +281,7 @@ public partial class ValidationRulesException<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRulesException<T> IsLengthLowerThan(string key, string value, int lowerThan, string message)
     {
-        if (value.Length < lowerThan)
+        if (value.Length > lowerThan)
             PublishException(new DomainException(key, message));
         
         return this;

--- a/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsLengthLowerThanTest.cs
+++ b/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsLengthLowerThanTest.cs
@@ -4,7 +4,7 @@
 public class IsLengthLowerThanTest
 {
     [TestMethod]
-    public void WhenStringIsLowerThan_ReturnNotification()
+    public void WhenStringIsLowerThan_NotReturnNotification()
     {
         // Arrange
         // Initialize the validation rules object for a generic type
@@ -14,10 +14,10 @@ public class IsLengthLowerThanTest
         
         // Act
         // Validate that the value is lower than the maximum value
-        validation.IsLengthGreaterThan("Value", value, size);
+        validation.IsLengthLowerThan("Value", value, size);
         
         // Assert
         // Verify that there are no validation notifications, indicating the value is lower than the maximum value
-        Assert.IsTrue(validation.HasNotifications);
+        Assert.IsTrue(!validation.HasNotifications);
     }
 }

--- a/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsNullOrEmptyTest.cs
+++ b/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsNullOrEmptyTest.cs
@@ -4,7 +4,7 @@
 public class IsNullOrEmptyTest
 {
     [TestMethod]
-    public void WhenStringIsNullOrEmpty_ReturnNotification()
+    public void WhenStringIsNullOrEmpty_NotReturnNotification()
     {
         // Arrange
         // Initialize the validation rules object for a generic type
@@ -17,6 +17,17 @@ public class IsNullOrEmptyTest
         
         // Assert
         // Verify that there are no validation notifications, indicating the string is not null or empty
+        Assert.IsTrue(!validation.HasNotifications);
+    }
+
+    [TestMethod]
+    public void WhenStringIsNotNullOrEmpty_ReturnNotification()
+    {
+        var validation = new ValidationRules<object>();
+        const string value = "abc";
+
+        validation.IsNullOrEmpty("Value", value);
+
         Assert.IsTrue(validation.HasNotifications);
     }
 }

--- a/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsNullOrWhiteSpaceTest.cs
+++ b/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsNullOrWhiteSpaceTest.cs
@@ -4,7 +4,7 @@
 public class IsNullOrWhiteSpaceTest
 {
     [TestMethod]
-    public void WhenStringIsNullOrWhiteSpace_ReturnNotification()
+    public void WhenStringIsNullOrWhiteSpace_NotReturnNotification()
     {
         // Arrange
         // Initialize the validation rules object for a generic type
@@ -17,11 +17,11 @@ public class IsNullOrWhiteSpaceTest
         
         // Assert
         // Verify that there are no validation notifications, indicating the string is not null or empty
-        Assert.IsTrue(validation.HasNotifications);
+        Assert.IsTrue(!validation.HasNotifications);
     }
     
     [TestMethod]
-    public void WhenStringIsNullOrEmpty_NotReturnNotification()
+    public void WhenStringIsNotNullOrWhiteSpace_ReturnNotification()
     {
         // Arrange
         // Initialize the validation rules object for a generic type
@@ -34,6 +34,6 @@ public class IsNullOrWhiteSpaceTest
         
         // Assert
         // Verify that there are no validation notifications, indicating the string is not null or empty
-        Assert.IsTrue(!validation.HasNotifications);
+        Assert.IsTrue(validation.HasNotifications);
     }
 }

--- a/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsNullTest.cs
+++ b/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsNullTest.cs
@@ -4,7 +4,7 @@
 public class IsNullTest
 {
     [TestMethod]
-    public void WhenStringIsNull_ReturnNotification()
+    public void WhenStringIsNull_NotReturnNotification()
     {
         // Arrange
         // Initialize the validation rules object for a generic type
@@ -17,11 +17,11 @@ public class IsNullTest
         
         // Assert
         // Verify that there are no validation notifications, indicating the string is not null
-        Assert.IsTrue(validation.HasNotifications);
+        Assert.IsTrue(!validation.HasNotifications);
     }
     
     [TestMethod]
-    public void WhenStringIsNull_NotReturnNotification()
+    public void WhenStringIsNotNull_ReturnNotification()
     {
         // Arrange
         // Initialize the validation rules object for a generic type
@@ -34,6 +34,6 @@ public class IsNullTest
         
         // Assert
         // Verify that there are no validation notifications, indicating the string is not null
-        Assert.IsTrue(!validation.HasNotifications);
+        Assert.IsTrue(validation.HasNotifications);
     }
 }


### PR DESCRIPTION
## Summary
- fix logic for IsNull family and IsLengthLowerThan
- update tests for new null semantics

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851471d41a48331a2c7a58fbe24d3f0