### PR TITLE
Fix typo in Error.cs comment

### DIFF
--- a/src/DevSource.Stack.Notifications/Error.cs
+++ b/src/DevSource.Stack.Notifications/Error.cs
@@ -66,7 +66,7 @@ public static class Error
     /// <summary>
     /// Creates a not null field error notification.
     /// </summary>
-    /// <param name="key">he key identifying the field that must not be null.</param>
+    /// <param name="key">The key identifying the field that must not be null.</param>
     /// <returns>A notification indicating that the field must not be null.</returns>
     public static string IsNotNullOrEmpty(string key)
         => $"The field '{key}' must not be null or empty";


### PR DESCRIPTION
## Summary
- fix a typo in the XML comment for `IsNotNullOrEmpty`

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851494b85388331ae4567d2c66f5ffd