### PR TITLE
Fix IsLengthLowerThan logic

### DIFF
--- a/src/DevSource.Stack.Notifications/Validations/ForStrings.cs
+++ b/src/DevSource.Stack.Notifications/Validations/ForStrings.cs
@@ -264,7 +264,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsLengthLowerThan(string key, string value, int lowerThan)
     {
-        if (value.Length > lowerThan)
+        if (value.Length >= lowerThan)
             AddNotification(new Notification(Error.IsLowerThan(key, lowerThan)));
         
         return this;
@@ -281,7 +281,7 @@ public partial class ValidationRules<T>
     /// <returns>The current instance of <see cref="ValidationRules{T}"/> after performing the validation.</returns>
     public ValidationRules<T> IsLengthLowerThan(string key, string value, int lowerThan, string message)
     {
-        if (value.Length > lowerThan)
+        if (value.Length >= lowerThan)
             AddNotification(new Notification(key, message));
         
         return this;


### PR DESCRIPTION
## Summary
- fix IsLengthLowerThan validation so equal lengths trigger notifications

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851494cfa848331b46286614f310fc9