### PR TITLE
Fix length lower than test

### DIFF
--- a/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsLengthLowerThanTest.cs
+++ b/tests/DevSource.Stack.Notifications.Tests/ForStrings/IsLengthLowerThanTest.cs
@@ -13,11 +13,11 @@ public class IsLengthLowerThanTest
         const int size = 10;
         
         // Act
-        // Validate that the value is lower than the maximum value
+        // Validate that the value does not exceed the maximum allowable length
         validation.IsLengthLowerThan("Value", value, size);
         
         // Assert
-        // Verify that there are no validation notifications, indicating the value is lower than the maximum value
+        // Verify that there are no validation notifications, indicating the value is within the allowed maximum length
         Assert.IsTrue(!validation.HasNotifications);
     }
 }


### PR DESCRIPTION
## Summary
- correct comments for maximum length validation
- ensure call to `IsLengthLowerThan` is used

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851494f7480833182c55fa3efd52572